### PR TITLE
added babel-core to install step in Lesson 5 to fix error

### DIFF
--- a/lesson_1.md
+++ b/lesson_1.md
@@ -71,6 +71,7 @@ A basic project is now setup. The folder structure should look like:
 .
 ├── lib
 │   └── index.html
+│   └── app.js
 └── package.json
 ```
 

--- a/lesson_5.md
+++ b/lesson_5.md
@@ -66,9 +66,10 @@ identical when executed, but is much easier to read when coding!
 Let's install some required tools to get us up and running:
 
 ```bash
-npm install --save-dev babelify babel-preset-react babel-preset-es2015
+npm install --save-dev babel-core babelify babel-preset-react babel-preset-es2015
 ```
 
+- `babel-core` is the core Babel compiler
 - `babelify` is a tool which tells Browserify how to handle this code when it
   is seen
 - `babel-preset-react` tells Babel that we want to handle react-specific (ie;

--- a/lesson_6.md
+++ b/lesson_6.md
@@ -13,7 +13,7 @@ React.render(
 ```
 
 In JSX, these attributes are known as *props*, and are available from within the
-component as the frist function parameter:
+component as the first function parameter:
 
 ```javascript
 function MyComponent(props) {


### PR DESCRIPTION
Students were encountering an error in this lesson, and one of them researched and found a solution here:
https://stackoverflow.com/questions/35215461/error-in-cannot-find-module-babel-core-using-react-js-webpack-and-express-s
Because this workshop uses Browserify and not Webpack, it looks like `babel-loader` is not needed, but `babel-core` is.